### PR TITLE
Changes to hero, home_landing_row, and footer that will allow it to display info from _config.yml

### DIFF
--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -12,7 +12,9 @@
     <a href="https://github.com/{{site.github_user}}"><img src="/images/glyphicons_social_21_github.png"/></a>
     {% endif %}
 
+    {% if site.email %}
     <a href="mailto:{{site.email}}"><img src="/images/glyphicons_social_39_e-mail.png"/></a>
+    {% endif %}
   </div>
 </div>
 

--- a/source/_includes/custom/hero.html
+++ b/source/_includes/custom/hero.html
@@ -1,2 +1,2 @@
-<h1>I'm Adrian Artiles</h1>
-<p>a developer & entrepreneur in San Francisco</p>
+<h1>{{ site.title }}</h1>
+<p>{{ site.subtitle }}</p>

--- a/source/_includes/custom/home_landing_row.html
+++ b/source/_includes/custom/home_landing_row.html
@@ -1,10 +1,15 @@
 <div id="about-me" class="col-md-offset-3 col-md-6">
   <h4>about me</h4>
-  <p>I'm a full-stack dev from Chicago now living in San Francisco. I build apps and products, such as <a href="https://www.GitRep.com">GitRep</a>, a platform that helps developers find and organize GitHub repos, and <a href="https://www.Lookira.com">Lookira</a>, a phone number owner reverse lookup site.</p>
-  <p>Here I ramble about things such as software development, building products, and living life. Radical!</p>
+  <p>{{ site.description }}</p>
   <div class="social-icon-list">
-    <a title="Twitter" href="https://twitter.com/AdrianArtiles"><img src="/images/glyphicons_social_31_twitter.png"/></a>
-    <a title="GitHub" href="https://github.com/sevenadrian"><img src="/images/glyphicons_social_21_github.png"/></a>
-    <a title="E-Mail" href="mailto:adrian.r.artiles@gmail.com"><img src="/images/glyphicons_social_39_e-mail.png"/></a>
+  	{% if site.twitter_user %}
+    <a title="Twitter" href="https://twitter.com/{{ site.twitter_user }}"><img src="/images/glyphicons_social_31_twitter.png"/></a>
+    {% endif %}
+    {% if site.github_user %}
+    <a title="GitHub" href="https://github.com/{{ site.github_user }}"><img src="/images/glyphicons_social_21_github.png"/></a>
+    {% endif %}
+    {% if site.email %}
+    <a title="E-Mail" href="{{ site.email }}"><img src="/images/glyphicons_social_39_e-mail.png"/></a>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Replaced hero.html content with `site.title` and `site.subtitle`. In footer.html, email icon now made dependent on `site.email`. In home_land_row.html, I added `site.description` under "about me" and made all 3 icons dependent on site configs.

These changes should make it easy for first time users of this theme to see all of the _config.yml settings immediately displayed. 
