### PR TITLE
Changed atom.xml and robots.txt from 'nil' to 'null'

### DIFF
--- a/source/atom.xml
+++ b/source/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 User-agent: *
 Disallow: 


### PR DESCRIPTION
The 'nil' argument for layout in both robots.txt and atom.xml is now obsolete and has been replaced with 'null'. I have updated both of these files.

Thank you for sharing your theme!